### PR TITLE
feat: api for decompose input

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,12 @@ OPENAI_API_KEY=sk-your_openai_key_here
 GOOGLE_API_KEY=your_google_ai_studio_key_here
 TAVILY_API_KEY=tvly-your_tavily_key_here
 
+# Jina Reader (URL → markdown for decompose_input). The default endpoint is
+# free but rate-limited (~20 req/min). Set JINA_API_KEY for higher limits —
+# get one at https://jina.ai/reader (free tier available).
+JINA_READER_BASE_URL=https://r.jina.ai/
+JINA_API_KEY=
+
 
 # ─── MODEL NAMES (safe defaults — override to experiment) ───────────────────
 LLM_MODEL=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -234,6 +234,37 @@ news_facts_system/
 
 ---
 
+## Public API for teammates: `decompose_input`
+
+`scraper_preprocessing_memory` exposes a single function teammates can call to
+push any user-supplied input (URL, article text, or short claim) into Neo4j +
+ChromaDB and get back the resulting `claim_id`s:
+
+```python
+from src.preprocessing.decompose import decompose_input
+
+claim_ids = decompose_input("Trump claims peace with Iran today.")
+claim_ids = decompose_input("https://www.bbc.com/news/articles/c62lp853214o")
+claim_ids = decompose_input(article_text_pasted_by_user)  # any length
+
+# → list[str], e.g. ["clm_a3f8b2c1", ...]
+```
+
+**Behaviour:**
+- **URL** → fetched as clean markdown via Jina Reader, then run through the same preprocessing pipeline as scraped articles.
+- **Article text** (≥500 chars or ≥2 sentences) → `gpt-4o-mini` infers / generates a title + body split, then full preprocessing.
+- **Short claim** → wrapped as a synthetic single-claim article so entity extraction still runs.
+- **Idempotent** — re-calling with the same input returns the same `claim_id`s (matched by content hash).
+- **Failure** — URLs that Jina cannot read raise `URLFetchError`; callers should catch and surface a clear message.
+
+Optional env vars (in `.env`):
+```
+JINA_READER_BASE_URL=https://r.jina.ai/   # default
+JINA_API_KEY=                              # leave blank for free tier; set for higher rate limits
+```
+
+---
+
 ## Troubleshooting
 
 - **Streamlit can't connect to Neo4j** — verify `NEO4J_URI` in `.env` matches the mode.

--- a/scraper_preprocessing_memory/data/sources.json
+++ b/scraper_preprocessing_memory/data/sources.json
@@ -54,5 +54,12 @@
     "domain": "reddit.com",
     "category": "social_media",
     "base_credibility": 0.25
+  },
+  {
+    "source_id": "src_frontend_local",
+    "name": "Frontend User Input",
+    "domain": "frontend.local",
+    "category": "user_input",
+    "base_credibility": 0.5
   }
 ]

--- a/scraper_preprocessing_memory/src/config.py
+++ b/scraper_preprocessing_memory/src/config.py
@@ -40,6 +40,11 @@ class Settings(BaseSettings):
     # EnsembleData API (Reddit keyword search)
     ensembledata_api_token: str = ""
 
+    # Jina Reader (URL → markdown for decompose_input)
+    # Free endpoint is rate-limited; set jina_api_key for higher limits.
+    jina_reader_base_url: str = "https://r.jina.ai/"
+    jina_api_key: str = ""
+
     # Model settings
     embedding_model: str = "gemini-embedding-001"
     embedding_dim: int = 1536

--- a/scraper_preprocessing_memory/src/memory/agent.py
+++ b/scraper_preprocessing_memory/src/memory/agent.py
@@ -295,6 +295,17 @@ class MemoryAgent:
         """Check if an article with this hash already exists."""
         return self._vector.check_content_hash_exists(content_hash)
 
+    def find_existing_claim_ids(self, content_hash: str) -> list[str]:
+        """Return claim_ids of an article matching this content_hash, or [].
+
+        Used by `decompose_input` to keep the public API idempotent: re-submitting
+        the same query returns the same claim_ids instead of creating duplicates.
+        """
+        article_id = self._vector.get_article_id_by_content_hash(content_hash)
+        if not article_id:
+            return []
+        return self._graph.get_claim_ids_for_article(article_id)
+
     def get_claims_by_ids(self, ids: list[str]) -> dict:
         return self._vector.get_claims_by_ids(ids)
 

--- a/scraper_preprocessing_memory/src/memory/graph_store.py
+++ b/scraper_preprocessing_memory/src/memory/graph_store.py
@@ -685,6 +685,18 @@ class GraphStore:
             )
             return [dict(record) for record in result]
 
+    def get_claim_ids_for_article(self, article_id: str) -> list[str]:
+        """Return all claim_ids attached to a given article (via CONTAINS edge)."""
+        with self._driver.session() as session:
+            result = session.run(
+                """
+                MATCH (a:Article {article_id: $article_id})-[:CONTAINS]->(c:Claim)
+                RETURN c.claim_id AS claim_id
+                """,
+                article_id=article_id,
+            )
+            return [record["claim_id"] for record in result]
+
     def auto_store_claim_with_entities(
         self,
         claim_id: str,

--- a/scraper_preprocessing_memory/src/memory/vector_store.py
+++ b/scraper_preprocessing_memory/src/memory/vector_store.py
@@ -106,6 +106,16 @@ class VectorStore:
         )
         return len(results["ids"]) > 0
 
+    def get_article_id_by_content_hash(self, content_hash: str):
+        """Return the article_id for an existing content_hash, or None."""
+        results = self._articles.get(
+            where={"content_hash": content_hash},
+            limit=1,
+        )
+        if results["ids"]:
+            return results["ids"][0]
+        return None
+
     # ── Verdicts ────────────────────────────────────────────────────────
 
     def upsert_verdict(

--- a/scraper_preprocessing_memory/src/preprocessing/agent.py
+++ b/scraper_preprocessing_memory/src/preprocessing/agent.py
@@ -1,7 +1,9 @@
 """Preprocessing Agent orchestrator — transforms raw articles into structured data."""
 
+import json
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 
 from src.config import Settings
 from src.id_utils import make_id
@@ -17,13 +19,42 @@ from src.scraper.fetchers.base import RawArticle
 
 logger = logging.getLogger(__name__)
 
-# Known source categories for credibility priors
-SOURCE_CATEGORIES = {
-    "bbc.co.uk": ("news_outlet", 0.90),
-    "reuters.com": ("wire_service", 0.95),
-    "apnews.com": ("wire_service", 0.95),
-    "t.me": ("social_media", 0.30),
-}
+
+# ── SOURCE_CATEGORIES — loaded once from data/sources.json ──────────────────
+# Single source of truth. The JSON is also used by scripts/seed_sources.py to
+# MERGE Source nodes into Neo4j; here we re-use it for the per-ingest credibility
+# lookup so seeding and ingestion can never disagree.
+#
+# Shape: { domain: (category, base_credibility) }
+# Domains not in this dict default to ("unknown", 0.50) at lookup time.
+
+_SOURCES_JSON_PATH = Path(__file__).resolve().parents[2] / "data" / "sources.json"
+
+
+def _load_source_categories() -> dict[str, tuple[str, float]]:
+    try:
+        entries = json.loads(_SOURCES_JSON_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        logger.warning("sources.json not found at %s; SOURCE_CATEGORIES is empty",
+                       _SOURCES_JSON_PATH)
+        return {}
+    except json.JSONDecodeError as e:
+        logger.error("sources.json is malformed (%s); SOURCE_CATEGORIES is empty", e)
+        return {}
+
+    out: dict[str, tuple[str, float]] = {}
+    for entry in entries:
+        domain = entry.get("domain")
+        if not domain:
+            continue
+        out[domain] = (
+            entry.get("category", "unknown"),
+            float(entry.get("base_credibility", 0.50)),
+        )
+    return out
+
+
+SOURCE_CATEGORIES = _load_source_categories()
 
 
 class PreprocessingAgent:

--- a/scraper_preprocessing_memory/src/preprocessing/decompose.py
+++ b/scraper_preprocessing_memory/src/preprocessing/decompose.py
@@ -1,0 +1,392 @@
+"""Public API for decomposing user-supplied input into claim_ids.
+
+This is the single entry point teammates (FakeNewsAgent / PredictionAgent)
+should import when they need to ingest a user query into Neo4j + ChromaDB and
+get back a list of claim_ids they can then fact-check or display.
+
+Usage
+-----
+    from src.preprocessing.decompose import decompose_input
+
+    claim_ids = decompose_input(query)   # query may be:
+                                         #   - a URL              (fetched via Jina Reader)
+                                         #   - a long article text (LLM splits title/body)
+                                         #   - a short claim       (wrapped in synthetic article)
+
+The function is **idempotent**: re-calling it with the same input returns the
+same claim_ids (looked up via the article's content_hash).
+
+URL fetch failures raise `URLFetchError` — callers should wrap in try/except
+and surface a clear message to the end user.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Literal, Optional
+from urllib.parse import urlparse
+
+import httpx
+from langfuse.decorators import observe
+from langfuse.openai import OpenAI
+
+from src.config import settings
+from src.memory.agent import MemoryAgent
+from src.preprocessing.agent import PreprocessingAgent
+from src.scraper.dedup import compute_content_hash
+from src.scraper.fetchers.base import RawArticle
+
+logger = logging.getLogger(__name__)
+
+
+# ── Public exception ─────────────────────────────────────────────────────────
+
+
+class URLFetchError(RuntimeError):
+    """Raised when Jina Reader cannot return usable content for a URL."""
+
+
+# ── Process-level singletons (lazily instantiated on first call) ─────────────
+
+
+_preprocessor: Optional[PreprocessingAgent] = None
+_memory: Optional[MemoryAgent] = None
+_openai_client: Optional[OpenAI] = None
+
+
+def _get_preprocessor() -> PreprocessingAgent:
+    global _preprocessor
+    if _preprocessor is None:
+        _preprocessor = PreprocessingAgent(settings)
+    return _preprocessor
+
+
+def _get_memory() -> MemoryAgent:
+    global _memory
+    if _memory is None:
+        _memory = MemoryAgent(settings)
+    return _memory
+
+
+def _get_openai_client() -> OpenAI:
+    """Reuse the langfuse-instrumented OpenAI client used by claim_isolator."""
+    global _openai_client
+    if _openai_client is None:
+        _openai_client = OpenAI(api_key=settings.openai_api_key)
+    return _openai_client
+
+
+# ── Input classification ─────────────────────────────────────────────────────
+
+
+_URL_RE = re.compile(r"^\s*https?://", re.IGNORECASE)
+_SENTENCE_RE = re.compile(r"[.!?]+\s+")
+_ARTICLE_LEN_THRESHOLD = 500  # chars; or 2+ sentences also counts as article
+
+
+def _classify(query: str) -> Literal["url", "article", "claim"]:
+    """Classify user input into one of three handling branches."""
+    q = query.strip()
+    if _URL_RE.match(q):
+        return "url"
+    if len(q) >= _ARTICLE_LEN_THRESHOLD or len(_SENTENCE_RE.findall(q)) >= 2:
+        return "article"
+    return "claim"
+
+
+# ── Branch helpers ───────────────────────────────────────────────────────────
+
+
+def _default_published_at() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _claim_to_raw(claim: str) -> RawArticle:
+    """Wrap a short claim as a synthetic single-claim article.
+
+    Title and body are both set to the claim text. PreprocessingAgent will run
+    claim_isolator + entity_extractor on it; for a one-sentence input this
+    produces ~1 claim equal to the input plus its extracted entities.
+    """
+    title = claim.strip()
+    body = title
+    return RawArticle(
+        url="",
+        title=title,
+        body_text=body,
+        image_urls=[],
+        source_name="Frontend User Input",
+        source_domain="frontend.local",
+        published_at=_default_published_at(),
+        content_hash=compute_content_hash(title, body),
+    )
+
+
+@observe(name="decompose_extract_title")
+def _extract_title_with_llm(text: str) -> tuple[bool, str, str]:
+    """Use gpt-4o-mini to detect/generate a title for an article body.
+
+    Returns (has_title, title, body) where:
+      - has_title: True if the input already has a natural title at the top
+      - title: the detected or generated title
+      - body: the article body (with title removed if has_title=True)
+
+    On any LLM error, returns (False, "", text) so caller can apply the
+    deterministic fallback heuristic.
+    """
+    prompt = (
+        "You are given an article-like text submitted by a user. Decide whether "
+        "the very first line/sentence is a natural title (a short headline-like "
+        "phrase) for the rest of the body, OR there is no title and the text is "
+        "just a body of paragraphs. If there is no natural title, generate a "
+        "concise headline yourself (under 15 words).\n\n"
+        "Respond ONLY with JSON of the shape:\n"
+        '{"has_title": bool, "title": "...", "body": "..."}\n\n'
+        "Rules:\n"
+        "- If has_title is true, `title` must be the original first headline "
+        "  verbatim and `body` must be the remaining text.\n"
+        "- If has_title is false, generate a `title` and copy the original "
+        "  text into `body` unchanged.\n"
+        "- Never invent facts not present in the text.\n\n"
+        f"Text:\n{text}"
+    )
+
+    try:
+        client = _get_openai_client()
+        response = client.chat.completions.create(
+            model=settings.llm_model,
+            messages=[{"role": "user", "content": prompt}],
+            response_format={"type": "json_object"},
+            temperature=0.0,
+        )
+        parsed = json.loads(response.choices[0].message.content or "{}")
+        has_title = bool(parsed.get("has_title", False))
+        title = (parsed.get("title") or "").strip()
+        body = (parsed.get("body") or "").strip()
+        if not title or not body:
+            raise ValueError("LLM returned empty title or body")
+        return has_title, title, body
+    except Exception as e:
+        logger.warning("LLM title extraction failed (%s); using heuristic fallback", e)
+        return False, "", text
+
+
+def _heuristic_title_split(text: str) -> tuple[str, str]:
+    """Fallback: first sentence (or first 100 chars) as title, rest as body."""
+    text = text.strip()
+    sentences = _SENTENCE_RE.split(text, maxsplit=1)
+    if len(sentences) == 2 and len(sentences[0]) <= 200:
+        title = sentences[0].strip().rstrip(".!?")
+        body = sentences[1].strip() or text
+        return title, body
+    # No sentence boundary in the first 200 chars — slice instead.
+    title = text[:100].strip()
+    body = text
+    return title, body
+
+
+def _article_to_raw(text: str) -> RawArticle:
+    """Wrap a long-form article text as a RawArticle.
+
+    Uses gpt-4o-mini to detect or generate a title; falls back to the
+    first-sentence heuristic if the LLM is unavailable.
+    """
+    has_title, title, body = _extract_title_with_llm(text)
+    if not title or not body:
+        title, body = _heuristic_title_split(text)
+
+    return RawArticle(
+        url="",
+        title=title,
+        body_text=body,
+        image_urls=[],
+        source_name="Frontend User Input",
+        source_domain="frontend.local",
+        published_at=_default_published_at(),
+        content_hash=compute_content_hash(title, body),
+    )
+
+
+# ── URL → RawArticle (Jina Reader) ──────────────────────────────────────────
+
+
+_JINA_HEADER_RE = re.compile(
+    r"^(?P<key>Title|URL Source|Published Time|Markdown Content):\s*(?P<value>.*)$",
+    re.MULTILINE,
+)
+_MD_IMAGE_RE = re.compile(r"!\[[^\]]*\]\((https?://[^)\s]+)\)")
+
+
+def _parse_jina_markdown(md: str) -> tuple[str, Optional[datetime], str]:
+    """Parse Jina Reader's markdown response into (title, published_at, body).
+
+    Jina Reader prefixes the document with a small header block:
+
+        Title: <article title>
+        URL Source: <url>
+        Published Time: <ISO date>
+        Markdown Content:
+        <…body…>
+
+    The body separator is the literal line `Markdown Content:`. If we can't
+    find it (Jina's format may evolve), treat the whole thing as body and
+    derive a title from the first non-empty line / first markdown heading.
+    """
+    headers = {}
+    for m in _JINA_HEADER_RE.finditer(md):
+        headers[m.group("key")] = m.group("value").strip()
+        # Stop scanning after the body separator
+        if m.group("key") == "Markdown Content":
+            break
+
+    title = headers.get("Title", "").strip()
+    published_iso = headers.get("Published Time", "").strip()
+
+    # Body = everything after "Markdown Content:" line
+    sep = "\nMarkdown Content:"
+    if sep in md:
+        body = md.split(sep, 1)[1].strip()
+    else:
+        body = md.strip()
+
+    # Defensive title fallback
+    if not title:
+        for line in body.splitlines():
+            line = line.strip().lstrip("# ").strip()
+            if line:
+                title = line[:200]
+                break
+
+    # Parse published date if present
+    published_at: Optional[datetime] = None
+    if published_iso:
+        try:
+            published_at = datetime.fromisoformat(published_iso.replace("Z", "+00:00"))
+        except ValueError:
+            published_at = None
+
+    return title, published_at, body
+
+
+def _url_to_raw(url: str) -> RawArticle:
+    """Fetch a URL via Jina Reader and convert to RawArticle.
+
+    Raises URLFetchError on HTTP failure or empty body.
+    """
+    headers = {"Accept": "text/markdown"}
+    if settings.jina_api_key:
+        headers["Authorization"] = f"Bearer {settings.jina_api_key}"
+
+    endpoint = f"{settings.jina_reader_base_url.rstrip('/')}/{url}"
+    try:
+        resp = httpx.get(endpoint, headers=headers, timeout=30.0)
+    except httpx.HTTPError as exc:
+        raise URLFetchError(f"Jina Reader request failed for {url}: {exc}") from exc
+
+    if resp.status_code >= 400:
+        raise URLFetchError(
+            f"Jina Reader returned {resp.status_code} for {url}: "
+            f"{resp.text[:200] if resp.text else '(no body)'}"
+        )
+
+    md = resp.text or ""
+    if not md.strip():
+        raise URLFetchError(f"Jina Reader returned empty body for {url}")
+
+    title, published_at, body = _parse_jina_markdown(md)
+    if not body.strip():
+        raise URLFetchError(f"Jina Reader returned no parseable body for {url}")
+
+    image_urls = _MD_IMAGE_RE.findall(body)
+    domain = urlparse(url).netloc or "frontend.local"
+
+    # Hash on the URL — NOT (title, body) — for URL submissions, because Jina
+    # Reader's markdown output drifts between fetches even when the underlying
+    # article is identical (relative timestamps, recommended-articles blocks,
+    # cache-buster query params on image URLs, whitespace nudges in markdown
+    # rendering). Using the canonical URL as the hash input gives stable
+    # idempotency across re-submissions of the same URL.
+    canonical_url = url.strip().lower()
+    content_hash = compute_content_hash(canonical_url, "")
+
+    return RawArticle(
+        url=url,
+        title=title or domain,
+        body_text=body,
+        image_urls=image_urls,
+        source_name=domain,
+        source_domain=domain,
+        published_at=published_at or _default_published_at(),
+        content_hash=content_hash,
+    )
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+
+def decompose_input(query: str) -> list[str]:
+    """Decompose a user query into claim_ids stored in Neo4j + ChromaDB.
+
+    Accepts three input shapes:
+      - URL                 → fetched via Jina Reader, treated as an article
+      - Long article text   → LLM splits into title + body, full pipeline
+      - Short claim text    → wrapped as a synthetic single-claim article
+
+    Returns the list of claim_ids written (or the existing claim_ids if the
+    same input was submitted before — idempotent on content_hash).
+
+    Raises:
+      URLFetchError  — if the input is a URL Jina cannot read.
+      ValueError     — if `query` is empty or only whitespace.
+    """
+    if not query or not query.strip():
+        raise ValueError("decompose_input received an empty query")
+
+    kind = _classify(query)
+    logger.info("decompose_input: classified as %s (len=%d)", kind, len(query))
+
+    if kind == "url":
+        raw = _url_to_raw(query.strip())
+    elif kind == "article":
+        raw = _article_to_raw(query.strip())
+    else:
+        raw = _claim_to_raw(query.strip())
+
+    memory = _get_memory()
+
+    # Fast-path: if we've already ingested this exact (title, body), return the
+    # existing claim_ids without re-running the LLM pipeline.
+    existing_ids = memory.find_existing_claim_ids(raw.content_hash)
+    if existing_ids:
+        logger.info(
+            "decompose_input: duplicate content_hash, returning %d existing claim_ids",
+            len(existing_ids),
+        )
+        return existing_ids
+
+    preprocessor = _get_preprocessor()
+    output = preprocessor.process(raw)
+
+    inserted = memory.ingest_preprocessed(output)
+    if not inserted:
+        # Race: someone else ingested between our find-existing check and ingest.
+        # Look up again so we still return a usable list.
+        existing_ids = memory.find_existing_claim_ids(raw.content_hash)
+        if existing_ids:
+            return existing_ids
+        logger.error(
+            "decompose_input: ingest reported duplicate but no claim_ids found "
+            "for content_hash=%s",
+            raw.content_hash,
+        )
+        return []
+
+    claim_ids = [c.claim_id for c in output.claims]
+    logger.info("decompose_input: ingested %d new claim_ids", len(claim_ids))
+    return claim_ids
+
+
+__all__ = ["decompose_input", "URLFetchError"]

--- a/scraper_preprocessing_memory/src/preprocessing/prompts.py
+++ b/scraper_preprocessing_memory/src/preprocessing/prompts.py
@@ -1,7 +1,7 @@
 """Centralized LLM prompt templates for the Preprocessing Agent."""
 
 CLAIM_ISOLATION_PROMPT = """\
-You are a fact-checking assistant. Given a news article, extract all falsifiable claims.
+You are a fact-checking assistant. Given a news article/short statement, extract all falsifiable claims.
 
 A falsifiable claim is a concrete statement that can be verified as true or false using evidence.
 If there is explicit expression of the statement source, it should also be included in the claim.


### PR DESCRIPTION
new api in scraper_preprocessing_memory.src.preprocessing.decompose `def decompose_input(query: str) -> list[str]`

- Decompose any user input (URL / article / claim) into claim_ids in the DB.

- Accepts three input shapes:

  1. URL                 → fetched via Jina Reader, treated as an article
  2. Long article text   → LLM splits into title + body, full pipeline
  3. Short claim text    → wrapped as a synthetic single-claim article

- Returns the list of claim_ids written (or the existing claim_ids if the same input was submitted before — idempotent on content_hash).
- Raises:
  - URLFetchError  — if the input is a URL Jina cannot read.
  - ValueError     — if `query` is empty or only whitespace.