### PR TITLE
fix: get_entity_by_name

### DIFF
--- a/scraper_preprocessing_memory/data/canonical_entities.json
+++ b/scraper_preprocessing_memory/data/canonical_entities.json
@@ -2,12 +2,12 @@
   {
     "canonical_name": "United States",
     "entity_type": "country",
-    "aliases": ["USA", "US", "U.S.", "U.S.A.", "America", "United States of America"]
+    "aliases": ["USA", "US", "U.S.", "U.S.A.", "States", "America", "United States of America"]
   },
   {
     "canonical_name": "United Kingdom",
     "entity_type": "country",
-    "aliases": ["UK", "U.K.", "Britain", "Great Britain"]
+    "aliases": ["UK", "U.K.", "Britain", "Great Britain", "England"]
   },
   {
     "canonical_name": "China",
@@ -42,7 +42,7 @@
   {
     "canonical_name": "Donald Trump",
     "entity_type": "person",
-    "aliases": ["Trump", "President Trump", "Donald J. Trump", "DJT"]
+    "aliases": ["Trump", "President Trump", "Donald J. Trump", "DJT", "Mr. Trump"]
   },
   {
     "canonical_name": "Joe Biden",

--- a/scraper_preprocessing_memory/src/memory/agent.py
+++ b/scraper_preprocessing_memory/src/memory/agent.py
@@ -350,8 +350,90 @@ class MemoryAgent:
         entity_id = self._graph.ensure_entity_exists(name)
         return self._graph.backfill_mentions_for_entity(entity_id, name)
 
-    def get_entity_by_name(self, name: str) -> Optional[dict]:
-        return self._graph.get_entity_by_name(name)
+    def get_entity_by_name(
+        self,
+        name: str,
+        fuzzy_threshold: int = 85,
+    ) -> Optional[dict]:
+        """Look up an Entity node by name with alias-aware multi-tier resolution.
+
+        Tier 1 — exact case-insensitive match on Entity.name in Neo4j.
+        Tier 2 — canonical alias resolution via data/canonical_entities.json
+                 (e.g. "USA" → "United States", "DPRK" → "North Korea").
+        Tier 3 — fuzzy string match across all Entity.name values using
+                 rapidfuzz.token_sort_ratio with a configurable threshold
+                 (default 85 — same threshold used by EntityMerger).
+
+        Returns the matched entity dict (same shape as graph.get_entity_by_name)
+        or None if no tier produces a match.
+
+        Backward-compatible: callers that pass only `name` see strictly more
+        matches than before; an exact match (Tier 1) returns immediately, so
+        existing well-formed inputs incur zero extra cost.
+
+        Notes
+        -----
+        - Names shorter than 3 chars skip Tier 3 (too short for reliable fuzzy
+          matching — would generate many false positives).
+        - Tier 3 fetches all Entity nodes from Neo4j once per call. For very
+          large graphs (10k+ entities) consider caching upstream.
+        """
+        if not name or not name.strip():
+            return None
+
+        # Tier 1: exact case-insensitive match
+        result = self._graph.get_entity_by_name(name)
+        if result:
+            return result
+
+        # Tier 2: canonical alias resolution (no entity_type known at query time)
+        from src.preprocessing.canonical_names import canonicalize_any_type
+        canonical = canonicalize_any_type(name)
+        if canonical and canonical.lower() != name.strip().lower():
+            result = self._graph.get_entity_by_name(canonical)
+            if result:
+                logger.info("get_entity_by_name: aliased '%s' → '%s'", name, canonical)
+                return result
+
+        # Tier 3: fuzzy match against all entity names
+        if len(name.strip()) < 3:
+            return None
+
+        try:
+            from rapidfuzz import fuzz, process
+        except ImportError:
+            logger.warning("rapidfuzz not available; skipping fuzzy entity lookup")
+            return None
+
+        all_entities = self._graph.get_all_entities()
+        if not all_entities:
+            return None
+
+        # Build name → entity map. Multiple entities may share the same name
+        # (rare after EntityMerger runs); we keep the one with the most claims.
+        name_to_entity: dict[str, dict] = {}
+        for e in all_entities:
+            existing = name_to_entity.get(e["name"])
+            if existing is None or (e.get("total_claims", 0) >
+                                    existing.get("total_claims", 0)):
+                name_to_entity[e["name"]] = e
+
+        match = process.extractOne(
+            name.strip(),
+            list(name_to_entity.keys()),
+            scorer=fuzz.token_sort_ratio,
+            score_cutoff=fuzzy_threshold,
+        )
+        if match is None:
+            return None
+
+        matched_name, score, _ = match
+        result = name_to_entity[matched_name]
+        logger.info(
+            "get_entity_by_name: fuzzy '%s' → '%s' (score=%.0f)",
+            name, matched_name, score,
+        )
+        return result
 
     def get_claim_count_for_entity(self, entity_id: str, since: datetime) -> int:
         return self._graph.get_claim_count_for_entity(entity_id, since)

--- a/scraper_preprocessing_memory/src/preprocessing/canonical_names.py
+++ b/scraper_preprocessing_memory/src/preprocessing/canonical_names.py
@@ -58,6 +58,20 @@ def _load_canonical_lookup() -> dict[tuple[str, str], str]:
 _CANONICAL_LOOKUP: dict[tuple[str, str], str] = _load_canonical_lookup()
 
 
+def _build_any_type_lookup(typed_lookup: dict[tuple[str, str], str]) -> dict[str, str]:
+    """Collapse a {(type, name_lower): canonical} dict into {name_lower: canonical}.
+
+    Used at query time when the caller doesn't know the entity_type
+    (e.g. a frontend lookup of "Trump"). Cross-type collisions resolve to
+    whichever entry was inserted last — acceptable since most aliases are
+    type-unique in practice.
+    """
+    return {name_lower: canonical for (_et, name_lower), canonical in typed_lookup.items()}
+
+
+_CANONICAL_LOOKUP_ANY_TYPE: dict[str, str] = _build_any_type_lookup(_CANONICAL_LOOKUP)
+
+
 def canonicalize(name: str, entity_type: str) -> str:
     """Return the canonical form of an entity name if it's a known alias.
 
@@ -70,6 +84,21 @@ def canonicalize(name: str, entity_type: str) -> str:
     stripped = name.strip()
     key = (entity_type.strip().lower(), stripped.lower())
     return _CANONICAL_LOOKUP.get(key, stripped)
+
+
+def canonicalize_any_type(name: str) -> str | None:
+    """Return canonical form for `name` ignoring entity_type, or None if unknown.
+
+    Used by query-time lookups (e.g. `MemoryAgent.get_entity_by_name`) where
+    the caller doesn't know which entity_type the name belongs to.
+
+    Example:
+        canonicalize_any_type("USA")    → "United States"
+        canonicalize_any_type("trump")  → None  (not in registry)
+    """
+    if not name or not name.strip():
+        return None
+    return _CANONICAL_LOOKUP_ANY_TYPE.get(name.strip().lower())
 
 
 def get_all_canonical_names() -> set[tuple[str, str]]:
@@ -98,5 +127,6 @@ def get_all_canonical_names() -> set[tuple[str, str]]:
 
 def reload_canonical_lookup() -> None:
     """Reload the lookup table from disk. Call after canonical_promoter appends new entries."""
-    global _CANONICAL_LOOKUP
+    global _CANONICAL_LOOKUP, _CANONICAL_LOOKUP_ANY_TYPE
     _CANONICAL_LOOKUP = _load_canonical_lookup()
+    _CANONICAL_LOOKUP_ANY_TYPE = _build_any_type_lookup(_CANONICAL_LOOKUP)


### PR DESCRIPTION
fix the `get_entity_by_name` so that it can not only get the entity by exact name, but also with semantic similar name