### PR TITLE
feat: add topic_text for claim

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@
 # ollama  → use local Ollama server (requires --profile ollama)
 LLM_PROVIDER=openai
 
-# gemini  → use Google Gemini embeddings (scapper's default, 1536-dim)
+# gemini  → use Google Gemini embeddings (scraper's default, 1536-dim)
 # openai  → use OpenAI text-embedding-3-small (1536-dim; requires re-seeding Chroma if switched)
 # ollama  → use Ollama nomic-embed-text (768-dim; REQUIRES wiping Chroma)
 EMBEDDING_PROVIDER=gemini
@@ -86,7 +86,7 @@ ENSEMBLEDATA_API_TOKEN=
 #       Langfuse wires in at import time (@observe decorators + langfuse.openai).
 #       The ONLY way to disable it is to leave LANGFUSE_PUBLIC_KEY and
 #       LANGFUSE_SECRET_KEY blank — the SDK then silently no-ops on every call.
-#       LANGFUSE_ENABLED / LANGFUSE_TRACING_ENABLED below DO NOT affect scapper.
+#       LANGFUSE_ENABLED / LANGFUSE_TRACING_ENABLED below DO NOT affect scraper.
 #
 #   FakeNewsAgent
 #       Reads LANGFUSE_ENABLED and LANGFUSE_TRACING_ENABLED and skips tracing

--- a/FakeNewsAgent/fact_check_agent/src/agents/reflection_agent.py
+++ b/FakeNewsAgent/fact_check_agent/src/agents/reflection_agent.py
@@ -147,12 +147,17 @@ def update_source_credibility(
     confidence_score: int,
     bias_score: float,
     memory: "MemoryAgent",
+    topic_text: str = "",
 ) -> None:
     """Append one new (source, topic, credibility, bias) observation after a verdict.
 
     Called by write_memory node. Always inserts — never overwrites. The full
     observation history is preserved so query-time aggregation can weight and
     average across all past verdicts for this (source, topic) region.
+
+    `topic_text` is the coarse topic category for the claim (e.g. "technology").
+    Empty string is acceptable — frontend direct-query path has no preprocessing
+    so no topic is available.
     """
     source_id   = source_id_from_url(source_url)
     credibility = credibility_signal(verdict_label, confidence_score)
@@ -163,7 +168,7 @@ def update_source_credibility(
         memory.add_source_credibility_point(
             point_id      = point_id,
             claim_text    = claim_text,
-            topic_text    = claim_text,
+            topic_text    = topic_text,
             source_id     = source_id,
             credibility   = credibility,
             bias          = bias_score,

--- a/FakeNewsAgent/fact_check_agent/src/graph/nodes.py
+++ b/FakeNewsAgent/fact_check_agent/src/graph/nodes.py
@@ -561,6 +561,7 @@ def write_memory(state: FactCheckState, memory: "MemoryAgent") -> dict:
         confidence_score= output.confidence_score,
         bias_score      = output.bias_score,
         memory          = memory,
+        topic_text      = state["input"].topic_text,
     )
 
     return {}

--- a/FakeNewsAgent/fact_check_agent/src/models/schemas.py
+++ b/FakeNewsAgent/fact_check_agent/src/models/schemas.py
@@ -43,6 +43,7 @@ class FactCheckInput(BaseModel):
     image_url: Optional[str] = None       # raw image URL or base64 data URI; used by cross-modal check
     timestamp: datetime
     prefetched_chunks: list[str] = Field(default_factory=list)  # pre-fetched evidence; skips live_search when non-empty
+    topic_text: str = ""              # coarse one-word topic (closed enum); "" for benchmark / synthetic-input paths
 
 
 # ── Output contract: Fact-Check Agent → Frontend / Memory ────────────────────

--- a/FakeNewsAgent/fact_check_agent/src/pipeline.py
+++ b/FakeNewsAgent/fact_check_agent/src/pipeline.py
@@ -67,6 +67,7 @@ def claim_to_fact_check_input(
         image_caption = image_caption,
         image_url     = image_url,
         timestamp     = claim.extracted_at,
+        topic_text    = getattr(claim, "topic_text", "") or "",
     )
 
 

--- a/PredictionAgent/agents/fact_check_agent.py
+++ b/PredictionAgent/agents/fact_check_agent.py
@@ -11,7 +11,7 @@ Public API for Streamlit frontend and other PredictionAgent code:
     output = fact_check_claim("Tesla recalled 500k vehicles due to brake defects")
 
 This file lives in the integrated monorepo and bridges the three subfolders
-by adjusting sys.path so `src.*` (scapper) and `fact_check_agent.src.*`
+by adjusting sys.path so `src.*` (scraper) and `fact_check_agent.src.*`
 (FakeNewsAgent) resolve from this process.
 """
 import logging
@@ -73,6 +73,7 @@ def _claim_to_input(
         image_caption=image_caption,
         image_url=image_url,
         timestamp=claim.extracted_at,
+        topic_text=getattr(claim, "topic_text", "") or "",
     )
 
 

--- a/PredictionAgent/agents/memory_agent.py
+++ b/PredictionAgent/agents/memory_agent.py
@@ -2,7 +2,7 @@
 
 The real implementation lives at `../../scraper_preprocessing_memory/src/memory/agent.py`.
 This file only:
-  1. Adjusts sys.path so scapper's `src.*` imports resolve.
+  1. Adjusts sys.path so scraper's `src.*` imports resolve.
   2. Re-exports `MemoryAgent` plus a process-level `get_memory()` singleton.
 
 Usage:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ docker compose -f docker/docker-compose.yml -f docker/docker-compose.local.yml \
 
 ```
 news_facts_system/
-├── scraper_preprocessing_memory/   # Kleivn's repo (near-verbatim)
+├── scraper_preprocessing_memory/   # Kelvin's repo (near-verbatim)
 │   └── src/
 │       ├── pipeline.py             # `python -m src.pipeline` entry
 │       ├── memory/agent.py         # Unified MemoryAgent — the single DB facade
@@ -187,7 +187,7 @@ news_facts_system/
 │   ├── frontend/app.py             # Streamlit UI
 │   ├── agents/
 │   │   ├── fact_check_agent.py     # NEW adapter — wraps FakeNewsAgent's pipeline
-│   │   ├── memory_agent.py         # NEW adapter — re-exports scapper's MemoryAgent
+│   │   ├── memory_agent.py         # NEW adapter — re-exports scraper's MemoryAgent
 │   │   ├── entity_tracker.py       # Task 3 (unchanged)
 │   │   └── prediction_agent.py     # Task 3 (unchanged)
 │   └── evaluation/
@@ -227,7 +227,7 @@ news_facts_system/
                 │ ingest_preprocessed()
                 │
    ┌────────────────────────┐
-   │ scapper pipeline       │   one-shot, periodic or on-demand
+   │ scraper pipeline       │   one-shot, periodic or on-demand
    │ (RSS / Tavily / …)     │
    └────────────────────────┘
 ```

--- a/scraper_preprocessing_memory/src/memory/agent.py
+++ b/scraper_preprocessing_memory/src/memory/agent.py
@@ -133,6 +133,7 @@ class MemoryAgent:
                 "claim_id": claim.claim_id,
                 "claim_text": claim.claim_text,
                 "claim_type": claim.claim_type or "",
+                "topic_text": claim.topic_text,
                 "extracted_at": claim.extracted_at.isoformat(),
                 "status": claim.status,
                 "entities": [
@@ -178,6 +179,7 @@ class MemoryAgent:
                 source_id=output.article.source_id,
                 status=claim.status,
                 extracted_at=claim.extracted_at.isoformat(),
+                topic_text=claim.topic_text,
             )
 
         # Image caption

--- a/scraper_preprocessing_memory/src/memory/graph_store.py
+++ b/scraper_preprocessing_memory/src/memory/graph_store.py
@@ -129,6 +129,7 @@ class GraphStore:
                         article_id: $article_id,
                         claim_text: $claim_text,
                         claim_type: $claim_type,
+                        topic_text: $topic_text,
                         extracted_at: datetime($extracted_at),
                         status: $status
                     })
@@ -138,6 +139,7 @@ class GraphStore:
                     claim_id=claim["claim_id"],
                     claim_text=claim["claim_text"],
                     claim_type=claim.get("claim_type", ""),
+                    topic_text=claim.get("topic_text", ""),
                     extracted_at=claim["extracted_at"],
                     status=claim.get("status", "pending"),
                 )

--- a/scraper_preprocessing_memory/src/memory/vector_store.py
+++ b/scraper_preprocessing_memory/src/memory/vector_store.py
@@ -47,6 +47,7 @@ class VectorStore:
         source_id: str,
         status: str,
         extracted_at: str,
+        topic_text: str = "",
     ) -> None:
         self._claims.upsert(
             ids=[claim_id],
@@ -57,6 +58,7 @@ class VectorStore:
                 "source_id": source_id,
                 "status": status,
                 "extracted_at": extracted_at,
+                "topic_text": topic_text,
             }],
         )
 

--- a/scraper_preprocessing_memory/src/models/claim.py
+++ b/scraper_preprocessing_memory/src/models/claim.py
@@ -26,6 +26,11 @@ class Claim(BaseModel):
     article_id: str
     claim_text: str
     claim_type: Optional[str] = None  # "statistical", "attribution", "causal", "predictive"
+    # Coarse one-word topic category. Closed enum (LLM-classified during isolation):
+    #   technology | geopolitics | financial | health | science |
+    #   sports | entertainment | climate | crime | other
+    # Default "" preserves backward-compat for fixtures and the synthetic-input path.
+    topic_text: str = ""
     extracted_at: datetime
     status: str = "pending"  # "pending", "verified", "expired"
     entities: list[MentionSentiment] = Field(default_factory=list)

--- a/scraper_preprocessing_memory/src/preprocessing/agent.py
+++ b/scraper_preprocessing_memory/src/preprocessing/agent.py
@@ -136,6 +136,7 @@ class PreprocessingAgent:
                 article_id=article_id,
                 claim_text=raw_claim["text"],
                 claim_type=raw_claim.get("type"),
+                topic_text=raw_claim.get("topic_text", ""),
                 extracted_at=now,
                 status="pending",
                 entities=mentions,

--- a/scraper_preprocessing_memory/src/preprocessing/claim_isolator.py
+++ b/scraper_preprocessing_memory/src/preprocessing/claim_isolator.py
@@ -44,6 +44,7 @@ class ClaimIsolator:
                     valid_claims.append({
                         "text": claim["text"],
                         "type": claim.get("type", ""),
+                        "topic_text": claim.get("topic_text", ""),
                     })
 
             logger.info("Extracted %d claims from article", len(valid_claims))

--- a/scraper_preprocessing_memory/src/preprocessing/prompts.py
+++ b/scraper_preprocessing_memory/src/preprocessing/prompts.py
@@ -7,11 +7,16 @@ A falsifiable claim is a concrete statement that can be verified as true or fals
 If there is explicit expression of the statement source, it should also be included in the claim.
 Exclude opinions, questions, and vague statements.
 
-For each claim, classify its type:
-- "statistical": involves numbers, percentages, quantities
-- "attribution": attributes an action or statement to a specific entity
-- "causal": asserts a cause-effect relationship
-- "predictive": makes a prediction about the future
+For each claim, also classify:
+1. type — one of:
+   - "statistical": involves numbers, percentages, quantities
+   - "attribution": attributes an action or statement to a specific entity
+   - "causal": asserts a cause-effect relationship
+   - "predictive": makes a prediction about the future
+2. topic_text — exactly ONE coarse topic category from this list:
+   technology | geopolitics | financial | health | science |
+   sports | entertainment | climate | crime | art
+   Pick the single best fit. Suggest one word only if no category applies.
 
 Article title: {title}
 
@@ -21,7 +26,11 @@ Article text:
 Return a JSON object with this structure:
 {{
   "claims": [
-    {{"text": "the exact falsifiable claim", "type": "statistical|attribution|causal|predictive"}}
+    {{
+      "text": "the exact falsifiable claim",
+      "type": "statistical|attribution|causal|predictive",
+      "topic_text": "technology|geopolitics|financial|health|science|sports|entertainment|climate|crime|art|"
+    }}
   ]
 }}
 


### PR DESCRIPTION
## Preprocessing emits topic_text
`scraper_preprocessing_memory/src/models/claim.py` — added topic_text: str = "" field on Claim with the closed-enum docstring.
`scraper_preprocessing_memory/src/preprocessing/prompts.py` — extended CLAIM_ISOLATION_PROMPT to require a topic_text value from the closed list technology|geopolitics|financial|health|science|sports|entertainment|climate|crime|other.
`scraper_preprocessing_memory/src/preprocessing/claim_isolator.py` — parser now pulls claim.get("topic_text", "") from the LLM JSON.
`scraper_preprocessing_memory/src/preprocessing/agent.py` — passes topic_text=raw_claim.get("topic_text", "") when constructing Claim instances.

## Memory persists topic_text
`scraper_preprocessing_memory/src/memory/graph_store.py` — create_claims_with_entities now writes topic_text onto the Neo4j Claim node.
`scraper_preprocessing_memory/src/memory/vector_store.py` — upsert_claim accepts topic_text and stores it in the claims collection metadata.
`scraper_preprocessing_memory/src/memory/agent.py` — ingest_preprocessed plumbs topic_text through the per-claim dict into both the graph and the vector store.

## FakeNewsAgent surfaces topic_text
`FakeNewsAgent/fact_check_agent/src/models/schemas.py` — FactCheckInput gains topic_text: str = "".
`FakeNewsAgent/fact_check_agent/src/pipeline.py` — claim_to_fact_check_input forwards claim.topic_text.
`FakeNewsAgent/fact_check_agent/src/agents/reflection_agent.py` — update_source_credibility now takes topic_text and passes it directly through topic_text=topic_text.
`FakeNewsAgent/fact_check_agent/src/graph/nodes.py` — write_memory node forwards state["input"].topic_text to update_source_credibility. Read path (query_memory / query_source_credibility) untouched.

## PredictionAgent adapter mirrors the wiring
`PredictionAgent/agents/fact_check_agent.py` — _claim_to_input adds topic_text=getattr(claim, "topic_text", "") or "". The fact_check_claim(str) synthetic-input path leaves topic_text="" (default).