### PR TITLE
Credibility fix

### DIFF
--- a/FakeNewsAgent/fact_check_agent/src/agents/context_claim_agent.py
+++ b/FakeNewsAgent/fact_check_agent/src/agents/context_claim_agent.py
@@ -33,6 +33,9 @@ from fact_check_agent.src.prompts import (
 
 logger = logging.getLogger(__name__)
 
+_MAX_MEMORY_CLAIMS = 5       # top-N prior verified claims passed to verdict synthesis
+_MAX_CLAIMS_PER_QUESTION = 2  # top-N Tavily results kept per question
+
 
 # ── Step 1: question generation ───────────────────────────────────────────────
 
@@ -200,6 +203,7 @@ def run(
     fresh_context: list[dict],
     prefetched_chunks: list[str],
     tavily_api_key: str,
+    input_url: str = "",
 ) -> list[dict]:
     """Run the context claim agent. Returns a list of context_claim dicts."""
     from fact_check_agent.src.tools.live_search_tool import search_live
@@ -279,9 +283,17 @@ def run(
         elif tavily_api_key:
             try:
                 results = search_live(q, api_key=tavily_api_key)
-                high_quality = [r for r in results if (r.get("score") or 0) >= 0.9]
+                high_quality = sorted(
+                    [
+                        r for r in results
+                        if (r.get("score") or 0) >= 0.85
+                        and r.get("url", "") != input_url
+                    ],
+                    key=lambda r: r.get("score") or 0.0,
+                    reverse=True,
+                )[:_MAX_CLAIMS_PER_QUESTION]
                 logger.info(
-                    "context_claim_agent: %d/%d Tavily results pass score≥0.9 for %r",
+                    "context_claim_agent: %d/%d Tavily results pass score≥0.85 (excl. input URL) for %r",
                     len(high_quality),
                     len(results),
                     q[:60],
@@ -304,15 +316,28 @@ def run(
                                 "confidence": None,
                                 "source": "tavily",
                                 "source_url": url,
+                                "score": result.get("score", 0.0),
                             }
                         )
             except Exception as exc:
                 logger.warning("Tavily search failed for %r: %s", q, exc)
 
+    # ── Context optimisation ─────────────────────────────────────────────────
+    # Memory claims: top 5 by prior confidence.
+    # Non-memory claims are already capped to _MAX_CLAIMS_PER_QUESTION before summarization.
+    memory_claims = sorted(
+        [c for c in context_claims if c["source"] == "memory"],
+        key=lambda c: c.get("confidence") or 0.0,
+        reverse=True,
+    )[:_MAX_MEMORY_CLAIMS]
+    non_memory_claims = [c for c in context_claims if c["source"] != "memory"]
+
+    context_claims = memory_claims + non_memory_claims
+
     logger.info(
-        "context_claim_agent: %d context claims (%d memory, %d factual, %d counter-factual)",
+        "context_claim_agent: %d context claims after optimisation (%d memory, %d factual, %d counter-factual)",
         len(context_claims),
-        sum(1 for c in context_claims if c["type"] == "memory"),
+        sum(1 for c in context_claims if c["source"] == "memory"),
         sum(1 for c in context_claims if c["type"] == "factual"),
         sum(1 for c in context_claims if c["type"] == "counter_factual"),
     )

--- a/FakeNewsAgent/fact_check_agent/src/config.py
+++ b/FakeNewsAgent/fact_check_agent/src/config.py
@@ -55,10 +55,6 @@ class Settings(BaseSettings):
 
     # Retrieval enhancements
     use_graph_rag: bool = False  # enable Neo4j entity-claim traversal in query_memory
-    use_cross_encoder: bool = (
-        False  # rerank merged results with cross-encoder (requires sentence-transformers)
-    )
-    cross_encoder_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
     reranker_top_k: int = 5  # final number of chunks passed to synthesizer
 
     # Cross-modal consistency — SigLIP

--- a/FakeNewsAgent/fact_check_agent/src/graph/graph.py
+++ b/FakeNewsAgent/fact_check_agent/src/graph/graph.py
@@ -25,11 +25,12 @@ from fact_check_agent.src.graph.nodes import (
     multi_agent_debate,
     query_memory,
     receive_claim,
+    return_cached_verdict,
     synthesize_verdict,
     vlm_assessment_node,
     write_memory,
 )
-from fact_check_agent.src.graph.router import debate_check
+from fact_check_agent.src.graph.router import cache_hit_check, debate_check
 from fact_check_agent.src.models.state import FactCheckState
 
 if TYPE_CHECKING:
@@ -99,6 +100,9 @@ def build_graph(memory: "MemoryAgent"):
     _write_memory = _timed("write_memory", lambda s: write_memory(s, memory))
     _receive_claim = _timed("receive_claim", receive_claim)
     _emit_output = _timed("emit_output", emit_output)
+    _return_cached_verdict = _timed(
+        "return_cached_verdict", lambda s: return_cached_verdict(s, memory)
+    )
 
     g = StateGraph(FactCheckState)
 
@@ -106,6 +110,7 @@ def build_graph(memory: "MemoryAgent"):
     g.add_node("receive_claim", _receive_claim)
     g.add_node("query_memory", _query_memory)
     g.add_node("freshness_check_all", _freshness_check_all)
+    g.add_node("return_cached_verdict", _return_cached_verdict)
     g.add_node("context_claim_agent", _context_claim_agent)
     g.add_node("vlm_assessment", _vlm_assessment)
     g.add_node("synthesize_verdict", _synthesize_verdict)
@@ -114,11 +119,21 @@ def build_graph(memory: "MemoryAgent"):
     g.add_node("write_memory", _write_memory)
     g.add_node("emit_output", _emit_output)
 
-    # ── Wire edges (linear — no routing before synthesis) ────────────────────
+    # ── Wire edges ───────────────────────────────────────────────────────────
     g.set_entry_point("receive_claim")
     g.add_edge("receive_claim", "query_memory")
     g.add_edge("query_memory", "freshness_check_all")
-    g.add_edge("freshness_check_all", "context_claim_agent")
+
+    # Cache hit check: near-identical fresh claim with high confidence → skip full pipeline
+    g.add_conditional_edges(
+        "freshness_check_all",
+        cache_hit_check,
+        {
+            "hit": "return_cached_verdict",
+            "miss": "context_claim_agent",
+        },
+    )
+    g.add_edge("return_cached_verdict", "write_memory")
     g.add_edge("context_claim_agent", "vlm_assessment")
     g.add_edge("vlm_assessment", "synthesize_verdict")
 

--- a/FakeNewsAgent/fact_check_agent/src/graph/nodes.py
+++ b/FakeNewsAgent/fact_check_agent/src/graph/nodes.py
@@ -141,15 +141,24 @@ def query_memory(state: FactCheckState, memory: "MemoryAgent", settings=None) ->
                 "GraphRAG: %d entities → %d graph claims", len(entity_ids), len(graph_results)
             )
 
-    # ── Stage 3: RRF merge + optional cross-encoder rerank ───────────────
+    # ── Stage 3: RRF merge ────────────────────────────────────────────────
     reranked = rerank_candidates(
         query=inp.claim_text,
         vector_results=vector_results,
         graph_results=graph_results,
-        use_cross_encoder=settings.use_cross_encoder,
-        cross_encoder_model=settings.cross_encoder_model,
         top_k=settings.reranker_top_k,
     )
+
+    # Batch-fetch verdict verified_at from Neo4j — authoritative source for timestamps.
+    # The ChromaDB per-claim lookup in rag_tool may miss recently-superseded verdicts
+    # or return stale metadata; a single Neo4j query is both faster and more accurate.
+    neo4j_timestamps: dict = {}
+    try:
+        claim_ids_for_ts = [c["claim_id"] for c in reranked if c.get("claim_id")]
+        if claim_ids_for_ts:
+            neo4j_timestamps = memory.get_verdict_timestamps_for_claims(claim_ids_for_ts)
+    except Exception as _ts_err:
+        logger.warning("query_memory: Neo4j timestamp batch lookup failed: %s", _ts_err)
 
     results = [
         SimilarClaim(
@@ -158,7 +167,8 @@ def query_memory(state: FactCheckState, memory: "MemoryAgent", settings=None) ->
             verdict_label=c.get("verdict_label"),
             verdict_confidence=c.get("verdict_confidence"),
             distance=c.get("distance", 0.0),
-            verified_at=c.get("verified_at"),
+            # Prefer Neo4j verified_at (authoritative); fall back to ChromaDB value
+            verified_at=neo4j_timestamps.get(c["claim_id"]) or c.get("verified_at"),
         )
         for c in reranked
     ]
@@ -182,13 +192,12 @@ def query_memory(state: FactCheckState, memory: "MemoryAgent", settings=None) ->
 
     logger.info(
         "query_memory: %d vector + %d graph → %d reranked, max_confidence=%.2f, "
-        "graph_rag=%s, cross_encoder=%s, topic=%s, source_cred_samples=%d",
+        "graph_rag=%s, topic=%s, source_cred_samples=%d",
         len(vector_results),
         len(graph_results),
         len(results),
         max_confidence,
         settings.use_graph_rag,
-        settings.use_cross_encoder,
         effective_topic,
         source_cred.get("sample_count", 0),
     )
@@ -199,6 +208,74 @@ def query_memory(state: FactCheckState, memory: "MemoryAgent", settings=None) ->
         "source_credibility": source_cred,
         "effective_topic": effective_topic,
     }
+
+
+# ── Node: return_cached_verdict ───────────────────────────────────────────────
+
+_CACHE_EXACT_DISTANCE = 0.05   # cosine distance below which a hit is "the same claim"
+_CACHE_MIN_CONFIDENCE = 0.70   # minimum stored confidence to trust the cached verdict
+
+
+def return_cached_verdict(state: FactCheckState, memory: "MemoryAgent") -> dict:
+    """Short-circuit node: reconstruct FactCheckOutput from the best fresh cache hit.
+
+    Only reached when cache_hit_check() returns "hit". Fetches the full verdict
+    reasoning from memory so the UI can display it without re-running synthesis.
+    """
+    inp = state["input"]
+    fresh = state.get("fresh_context") or []
+
+    # Pick the nearest qualifying hit (lowest distance above confidence threshold)
+    qualifying = [
+        c for c in fresh
+        if c.get("distance", 1.0) < _CACHE_EXACT_DISTANCE
+        and (c.get("verdict_confidence") or 0.0) >= _CACHE_MIN_CONFIDENCE
+        and c.get("verdict_label")
+    ]
+    if not qualifying:
+        logger.warning("return_cached_verdict: no qualifying hit in fresh_context — state mismatch")
+        return {}
+
+    best = min(qualifying, key=lambda c: c.get("distance", 1.0))
+
+    # Fetch full verdict text from memory (evidence_summary stored as ChromaDB document)
+    reasoning = f"[Cached verdict for similar claim: \"{best['claim_text'][:120]}\"]"
+    evidence_links: list[str] = []
+    verdict_id = f"cached_{best['claim_id']}"
+    cross_modal_flag = False
+
+    try:
+        verdict_raw = memory.get_verdict_by_claim(best["claim_id"])
+        if verdict_raw.get("ids"):
+            verdict_id = verdict_raw["ids"][0]
+        if verdict_raw.get("documents") and verdict_raw["documents"]:
+            reasoning = verdict_raw["documents"][0] or reasoning
+        if verdict_raw.get("metadatas") and verdict_raw["metadatas"]:
+            meta = verdict_raw["metadatas"][0]
+            cross_modal_flag = bool(meta.get("image_mismatch", False))
+    except Exception as exc:
+        logger.warning("return_cached_verdict: verdict fetch failed (%s) — using stub reasoning", exc)
+
+    raw_conf = best.get("verdict_confidence") or 0.0
+    confidence_score = int(round(raw_conf * 100)) if raw_conf <= 1.0 else int(round(raw_conf))
+    confidence_score = max(0, min(100, confidence_score))
+
+    output = FactCheckOutput(
+        verdict_id=verdict_id,
+        claim_id=inp.claim_id,
+        verdict=best["verdict_label"],
+        confidence_score=confidence_score,
+        evidence_links=evidence_links,
+        reasoning=reasoning,
+        cross_modal_flag=cross_modal_flag,
+        last_verified_at=best.get("verified_at"),
+    )
+
+    logger.info(
+        "return_cached_verdict: cache hit → verdict=%s conf=%d dist=%.4f cached_claim=%s",
+        output.verdict, output.confidence_score, best["distance"], best["claim_id"],
+    )
+    return {"output": output}
 
 
 # ── Node: freshness_check_all ─────────────────────────────────────────────────
@@ -261,6 +338,7 @@ def context_claim_agent_node(state: FactCheckState, memory: "MemoryAgent", setti
         fresh_context=state.get("fresh_context", []),
         prefetched_chunks=state.get("retrieved_chunks", []),
         tavily_api_key=settings.tavily_api_key,
+        input_url=state["input"].source_url or "",
     )
 
     effective_topic = state.get("effective_topic", "") or state["input"].topic_text

--- a/FakeNewsAgent/fact_check_agent/src/graph/router.py
+++ b/FakeNewsAgent/fact_check_agent/src/graph/router.py
@@ -3,6 +3,34 @@
 from fact_check_agent.src.config import settings
 from fact_check_agent.src.models.state import FactCheckState
 
+# Mirrors the constants in nodes.py — both must be kept in sync.
+_CACHE_EXACT_DISTANCE = 0.05
+_CACHE_MIN_CONFIDENCE = 0.70
+
+
+def cache_hit_check(state: FactCheckState) -> str:
+    """Route to cached verdict when a near-identical fresh claim exists in memory.
+
+    Returns "hit" when ALL of the following hold:
+      - At least one fresh_context entry has distance < _CACHE_EXACT_DISTANCE
+        (same claim, not just a similar one)
+      - That entry's verdict_confidence >= _CACHE_MIN_CONFIDENCE
+      - offline_mode is not active (cache bypass not forced)
+
+    Returns "miss" otherwise → normal pipeline continues.
+    """
+    if settings.offline_mode:
+        return "miss"
+
+    fresh = state.get("fresh_context") or []
+    for chunk in fresh:
+        dist = chunk.get("distance", 1.0)
+        conf = chunk.get("verdict_confidence") or 0.0
+        label = chunk.get("verdict_label")
+        if dist < _CACHE_EXACT_DISTANCE and conf >= _CACHE_MIN_CONFIDENCE and label:
+            return "hit"
+    return "miss"
+
 
 def debate_check(state: FactCheckState) -> str:
     """Decide whether to trigger multi-agent debate or VLM-only judge.

--- a/FakeNewsAgent/fact_check_agent/src/prompts.py
+++ b/FakeNewsAgent/fact_check_agent/src/prompts.py
@@ -26,6 +26,10 @@ Di SCALE — use EXACTLY one of these five values per item:
 IMPORTANT: For COUNTER-FACTUAL items — if the evidence confirms the counter-factual
 question, that CHALLENGES the main claim → assign a NEGATIVE degree.
 
+IMPORTANT: For MEMORY items — treat the prior verdict as the primary signal: "supported"
+→ positive Di, "refuted" → negative Di, scaled by how closely the memory claim matches
+the current one. Trust the prior verdict; do not re-litigate it from your own knowledge.
+
 In the "reasoning" field, describe the evidence by its actual text/content, NOT by number.
 Good: "Reuters reported the recall affected 500 vehicles, directly supporting the claim."
 Bad: "Evidence [3] supports the claim." — the user never sees the evidence numbers.

--- a/FakeNewsAgent/fact_check_agent/src/tools/reranker.py
+++ b/FakeNewsAgent/fact_check_agent/src/tools/reranker.py
@@ -1,15 +1,10 @@
-"""Retrieval reranking: Reciprocal Rank Fusion + optional cross-encoder.
+"""Retrieval reranking: Reciprocal Rank Fusion.
 
-Two-stage pipeline:
-  1. RRF  — merges vector DB results and graph entity-claim results into one
-            ranked list without needing score normalisation.
-  2. Cross-encoder (optional, gated by USE_CROSS_ENCODER) — rescores each
-            candidate against the query using a local sentence-transformers
-            model for higher accuracy.
+Merges vector DB results and graph entity-claim results into one ranked list
+without needing score normalisation.
 """
 
 import logging
-from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -42,60 +37,17 @@ def reciprocal_rank_fusion(
     return merged
 
 
-@lru_cache(maxsize=1)
-def _load_cross_encoder(model_name: str):
-    from sentence_transformers import CrossEncoder
-
-    logger.info("Loading cross-encoder model: %s", model_name)
-    return CrossEncoder(model_name)
-
-
-def cross_encoder_rerank(
-    query: str,
-    candidates: list[dict],
-    model_name: str,
-    top_k: int,
-    text_key: str = "claim_text",
-) -> list[dict]:
-    """Rerank candidates using a cross-encoder model.
-
-    Scores each (query, candidate_text) pair, returns top_k sorted by score.
-    Falls back to the original order if the model fails.
-    """
-    if not candidates:
-        return candidates
-
-    try:
-        model = _load_cross_encoder(model_name)
-        pairs = [(query, c[text_key]) for c in candidates]
-        scores = model.predict(pairs)
-        ranked = sorted(zip(scores, candidates), key=lambda x: x[0], reverse=True)
-        result = []
-        for score, item in ranked[:top_k]:
-            item = dict(item)
-            item["cross_encoder_score"] = float(score)
-            result.append(item)
-        logger.debug("Cross-encoder reranked %d → %d candidates", len(candidates), len(result))
-        return result
-    except Exception as e:
-        logger.error("Cross-encoder reranking failed: %s — returning original order", e)
-        return candidates[:top_k]
-
-
 def rerank_candidates(
     query: str,
     vector_results: list[dict],
     graph_results: list[dict],
-    use_cross_encoder: bool,
-    cross_encoder_model: str,
     top_k: int,
 ) -> list[dict]:
-    """Full reranking pipeline: RRF merge then optional cross-encoder.
+    """Rerank pipeline: RRF merge of vector and graph results.
 
     Args:
         vector_results: Ranked list from ChromaDB similarity search.
         graph_results:  Ranked list from Neo4j entity-claim traversal.
-        use_cross_encoder: If True, apply cross-encoder after RRF.
         top_k: Maximum number of results to return.
 
     Returns:
@@ -107,17 +59,13 @@ def rerank_candidates(
         return []
 
     if len(lists_to_merge) == 1:
-        merged = lists_to_merge[0][:top_k]
-    else:
-        merged = reciprocal_rank_fusion(lists_to_merge)
-        logger.info(
-            "RRF merged %d vector + %d graph → %d unique candidates",
-            len(vector_results),
-            len(graph_results),
-            len(merged),
-        )
+        return lists_to_merge[0][:top_k]
 
-    if use_cross_encoder:
-        return cross_encoder_rerank(query, merged, cross_encoder_model, top_k)
-
+    merged = reciprocal_rank_fusion(lists_to_merge)
+    logger.info(
+        "RRF merged %d vector + %d graph → %d unique candidates",
+        len(vector_results),
+        len(graph_results),
+        len(merged),
+    )
     return merged[:top_k]

--- a/FakeNewsAgent/fact_check_agent/tests/test_reranker.py
+++ b/FakeNewsAgent/fact_check_agent/tests/test_reranker.py
@@ -2,9 +2,8 @@
 
 Covers:
   - reciprocal_rank_fusion: merge, deduplication, ordering
-  - cross_encoder_rerank: top_k, score attachment, error fallback
-  - rerank_candidates: RRF-only, RRF+cross-encoder, single list, empty input
-  - query_memory node: USE_GRAPH_RAG flag, USE_CROSS_ENCODER flag, verdict revision
+  - rerank_candidates: RRF merge, single list, empty input
+  - query_memory node: USE_GRAPH_RAG flag, verdict revision
 """
 
 import json
@@ -86,15 +85,13 @@ def test_rrf_one_empty_one_populated():
 # ── rerank_candidates ─────────────────────────────────────────────────────────
 
 
-def test_rerank_candidates_rrf_only_no_cross_encoder():
+def test_rerank_candidates_rrf_merge():
     vector = [make_claim("c1"), make_claim("c2"), make_claim("c3")]
     graph = [make_claim("c4"), make_claim("c1")]  # c1 appears in both
     result = rerank_candidates(
         query="test query",
         vector_results=vector,
         graph_results=graph,
-        use_cross_encoder=False,
-        cross_encoder_model="",
         top_k=3,
     )
     ids = [r["claim_id"] for r in result]
@@ -109,8 +106,6 @@ def test_rerank_candidates_top_k_respected():
         query="q",
         vector_results=vector,
         graph_results=[],
-        use_cross_encoder=False,
-        cross_encoder_model="",
         top_k=4,
     )
     assert len(result) == 4
@@ -121,8 +116,6 @@ def test_rerank_candidates_empty_inputs():
         query="q",
         vector_results=[],
         graph_results=[],
-        use_cross_encoder=False,
-        cross_encoder_model="",
         top_k=5,
     )
     assert result == []
@@ -134,49 +127,9 @@ def test_rerank_candidates_graph_only():
         query="q",
         vector_results=[],
         graph_results=graph,
-        use_cross_encoder=False,
-        cross_encoder_model="",
         top_k=5,
     )
     assert [r["claim_id"] for r in result] == ["g1", "g2"]
-
-
-def test_rerank_candidates_cross_encoder_called_when_enabled():
-    vector = [make_claim("c1"), make_claim("c2")]
-    with patch("fact_check_agent.src.tools.reranker._load_cross_encoder") as mock_load:
-        mock_model = MagicMock()
-        mock_model.predict.return_value = [0.9, 0.3]
-        mock_load.return_value = mock_model
-
-        result = rerank_candidates(
-            query="q",
-            vector_results=vector,
-            graph_results=[],
-            use_cross_encoder=True,
-            cross_encoder_model="cross-encoder/ms-marco-MiniLM-L-6-v2",
-            top_k=2,
-        )
-
-    mock_model.predict.assert_called_once()
-    assert result[0]["claim_id"] == "c1"  # higher score
-    assert result[0]["cross_encoder_score"] == pytest.approx(0.9)
-
-
-def test_rerank_candidates_cross_encoder_fallback_on_error():
-    vector = [make_claim("c1"), make_claim("c2"), make_claim("c3")]
-    with patch("fact_check_agent.src.tools.reranker._load_cross_encoder") as mock_load:
-        mock_load.side_effect = RuntimeError("model not found")
-        result = rerank_candidates(
-            query="q",
-            vector_results=vector,
-            graph_results=[],
-            use_cross_encoder=True,
-            cross_encoder_model="bad-model",
-            top_k=2,
-        )
-    # Falls back to original order, top_k respected
-    assert len(result) == 2
-    assert result[0]["claim_id"] == "c1"
 
 
 # ── query_memory node with GraphRAG flags ─────────────────────────────────────
@@ -203,18 +156,9 @@ def make_memory_mock_with_similar(claims=None):
     return memory
 
 
-def _make_settings(use_graph_rag=False, use_cross_encoder=False, top_k=5):
-    """Build a settings MagicMock with all guards explicitly set false.
-
-    MagicMock's default behaviour is to return a fresh MagicMock for any unset
-    attribute, and a MagicMock is truthy. That means `if settings.offline_mode:`
-    in query_memory short-circuits to True unless we set offline_mode=False
-    here, causing tests to fail with "expected call ... Called 0 times."
-    """
+def _make_settings(use_graph_rag=False, top_k=5):
     s = MagicMock()
     s.use_graph_rag = use_graph_rag
-    s.use_cross_encoder = use_cross_encoder
-    s.cross_encoder_model = "" if not use_cross_encoder else "cross-encoder/ms-marco-MiniLM-L-6-v2"
     s.reranker_top_k = top_k
     s.offline_mode = False
     s.dry_run = False
@@ -275,7 +219,6 @@ def test_query_memory_graph_rag_enabled_calls_entity_expansion():
 
     memory.get_entity_ids_for_claims.assert_called_once_with(["c1"])
     memory.get_graph_claims_for_entities.assert_called_once_with(["ent_1"])
-    # Both c1 (vector) and c2 (graph) should appear in results
     ids = [r.claim_id for r in result["memory_results"].results]
     assert "c1" in ids
     assert "c2" in ids
@@ -285,7 +228,7 @@ def test_query_memory_graph_rag_no_vector_results_skips_expansion():
     """With USE_GRAPH_RAG=true but no vector results, graph expansion is skipped."""
     from fact_check_agent.src.graph.nodes import query_memory
 
-    memory = make_memory_mock_with_similar([])  # empty vector results
+    memory = make_memory_mock_with_similar([])
     settings = _make_settings(use_graph_rag=True)
 
     state = {"input": make_fci()}
@@ -298,36 +241,10 @@ def test_query_memory_graph_rag_no_vector_results_skips_expansion():
     memory.get_entity_ids_for_claims.assert_not_called()
 
 
-def test_query_memory_cross_encoder_called_when_flag_set():
-    """With USE_CROSS_ENCODER=true, cross_encoder_rerank is invoked."""
-    from fact_check_agent.src.graph.nodes import query_memory
-
-    similar = [make_claim("c1"), make_claim("c2")]
-    memory = make_memory_mock_with_similar(similar)
-
-    settings = _make_settings(use_cross_encoder=True)
-
-    state = {"input": make_fci()}
-    with (
-        patch("fact_check_agent.src.tools.reranker._load_cross_encoder") as mock_load,
-        patch(
-            "fact_check_agent.src.agents.reflection_agent.query_source_credibility",
-            return_value={"sample_count": 0},
-        ),
-    ):
-        mock_model = MagicMock()
-        mock_model.predict.return_value = [0.8, 0.5]
-        mock_load.return_value = mock_model
-        query_memory(state, memory, settings)
-
-    mock_model.predict.assert_called_once()
-
-
 # ── Verdict revision ──────────────────────────────────────────────────────────
 
 
 def _ensure_memory_agent_env():
-    """Set minimum env vars so memory_agent Settings() can be instantiated."""
     import os
 
     os.environ.setdefault("NEO4J_URI", "bolt://localhost:7687")
@@ -336,7 +253,6 @@ def _ensure_memory_agent_env():
 
 
 def _stub_missing_modules():
-    """Stub heavy/unavailable deps so src.memory.agent can be imported in CI."""
     import sys
     from unittest.mock import MagicMock as _M
 
@@ -349,7 +265,6 @@ def _stub_missing_modules():
         "chromadb",
     ]:
         sys.modules.setdefault(mod, _M())
-    # google.genai must also be reachable as google_mod.genai
     google_mod = sys.modules.get("google", _M())
     if not hasattr(google_mod, "genai"):
         google_mod.genai = sys.modules["google.genai"]

--- a/scraper_preprocessing_memory/src/memory/agent.py
+++ b/scraper_preprocessing_memory/src/memory/agent.py
@@ -337,6 +337,9 @@ class MemoryAgent:
     def get_verdict_by_claim(self, claim_id: str) -> dict:
         return self._vector.get_verdict_by_claim(claim_id)
 
+    def get_verdict_timestamps_for_claims(self, claim_ids: list[str]) -> dict:
+        return self._graph.get_verdict_timestamps_for_claims(claim_ids)
+
     def get_entity_context(self, claim_id: str) -> list[dict]:
         return self._graph.get_entity_context(claim_id)
 

--- a/scraper_preprocessing_memory/src/memory/graph_store.py
+++ b/scraper_preprocessing_memory/src/memory/graph_store.py
@@ -260,6 +260,44 @@ class GraphStore:
                 new_id=new_verdict_id,
             )
 
+    def get_verdict_timestamps_for_claims(
+        self, claim_ids: list[str]
+    ) -> dict[str, datetime]:
+        """Batch fetch the latest non-superseded verdict verified_at for each claim_id.
+
+        Returns a dict mapping claim_id → verified_at (UTC-aware datetime).
+        Missing entries mean no active verdict exists for that claim.
+        """
+        if not claim_ids:
+            return {}
+        with self._driver.session() as session:
+            result = session.run(
+                """
+                UNWIND $claim_ids AS cid
+                MATCH (c:Claim {claim_id: cid})-[:VERIFIED_AS]->(v:Verdict)
+                WHERE NOT (v)-[:SUPERSEDED_BY]->()
+                RETURN c.claim_id AS claim_id, v.verified_at AS verified_at
+                ORDER BY v.verified_at DESC
+                """,
+                claim_ids=claim_ids,
+            )
+            seen: dict[str, datetime] = {}
+            for record in result:
+                cid = record["claim_id"]
+                if cid in seen:
+                    continue  # already have the most recent (ORDER BY DESC)
+                raw_ts = record["verified_at"]
+                if raw_ts is None:
+                    continue
+                try:
+                    ts = raw_ts.to_native() if hasattr(raw_ts, "to_native") else datetime.fromisoformat(str(raw_ts))
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                    seen[cid] = ts
+                except Exception:
+                    pass
+            return seen
+
     # ── Write: Credibility Snapshots (called by Entity Tracker) ─────────
 
     def create_snapshot(

--- a/scraper_preprocessing_memory/src/preprocessing/decompose.py
+++ b/scraper_preprocessing_memory/src/preprocessing/decompose.py
@@ -85,6 +85,7 @@ def _get_openai_client() -> OpenAI:
 _URL_RE = re.compile(r"^\s*https?://", re.IGNORECASE)
 _SENTENCE_RE = re.compile(r"[.!?]+\s+")
 _ARTICLE_LEN_THRESHOLD = 500  # chars; or 2+ sentences also counts as article
+_CLAIM_ISOLATION_BODY_LIMIT = 3000  # chars sent to ClaimIsolator; lead paragraphs have the key claims
 
 
 def _classify(query: str) -> Literal["url", "article", "claim"]:
@@ -198,10 +199,13 @@ def _article_to_raw(text: str) -> RawArticle:
     if not title or not body:
         title, body = _heuristic_title_split(text)
 
+    # Hash on the full body so deduplication is accurate even when two articles
+    # share the same lead but differ later. ClaimIsolator only sees the truncated
+    # portion — lead paragraphs contain the primary verifiable claims.
     return RawArticle(
         url="",
         title=title,
-        body_text=body,
+        body_text=body[:_CLAIM_ISOLATION_BODY_LIMIT],
         image_urls=[],
         source_name="Frontend User Input",
         source_domain="frontend.local",
@@ -315,7 +319,7 @@ def _url_to_raw(url: str) -> RawArticle:
     return RawArticle(
         url=url,
         title=title or domain,
-        body_text=body,
+        body_text=body[:_CLAIM_ISOLATION_BODY_LIMIT],
         image_urls=image_urls,
         source_name=domain,
         source_domain=domain,

--- a/scraper_preprocessing_memory/src/preprocessing/prompts.py
+++ b/scraper_preprocessing_memory/src/preprocessing/prompts.py
@@ -1,11 +1,20 @@
 """Centralized LLM prompt templates for the Preprocessing Agent."""
 
 CLAIM_ISOLATION_PROMPT = """\
-You are a fact-checking assistant. Given a news article/short statement, extract all falsifiable claims, at least 1.
+You are a fact-checking assistant. Extract the 1–3 most important falsifiable claims from the article below.
 
-A falsifiable claim is a concrete statement that can be verified as true or false using evidence.
-If there is explicit expression of the statement source, it should also be included in the claim.
-Exclude opinions, questions, and vague statements.
+A falsifiable claim is a concrete, specific statement that can be verified as true or false using evidence.
+
+Rules:
+- Prioritise claims that are CENTRAL to the article's main argument, not background or supporting details.
+- Each claim must be SELF-CONTAINED: replace all pronouns ("it", "they", "this policy", "the company") \
+with the actual named subject. A reader with no article context must understand the claim.
+- EXCLUDE hedged or modal claims ("may", "might", "could", "allegedly", "reportedly") unless the hedge \
+is itself the checkable fact (e.g. "X denied that Y happened" or "Officials claim Z").
+- EXCLUDE vague quantity claims that lack a specific value (e.g. "sales increased significantly").
+- EXCLUDE opinions, predictions about opinions, and rhetorical questions.
+- If the statement source is explicit, include it in the claim text.
+- Return AT MOST 3 claims, ranked by verifiability and centrality to the article.
 
 For each claim, also classify:
 1. type — one of:
@@ -16,20 +25,20 @@ For each claim, also classify:
 2. topic_text — exactly ONE coarse topic category from this list:
    technology | geopolitics | financial | health | science |
    sports | entertainment | climate | crime | art
-   Pick the single best fit. Suggest one word only if no category applies.
+   Pick the single best fit. Use one descriptive word only if truly no category applies.
 
-Article title, if this is a one sentence short statement, use it for title: {title}
+Article title: {title}
 
-Article text:
+Article text (extract claims from this):
 {body_text}
 
 Return a JSON object with this structure:
 {{
   "claims": [
     {{
-      "text": "the exact falsifiable claim",
+      "text": "the exact falsifiable claim, fully self-contained",
       "type": "statistical|attribution|causal|predictive",
-      "topic_text": "technology|geopolitics|financial|health|science|sports|entertainment|climate|crime|art|"
+      "topic_text": "technology|geopolitics|financial|health|science|sports|entertainment|climate|crime|art"
     }}
   ]
 }}


### PR DESCRIPTION
Duplicate Claim Cache Short-Circuit
When a claim has already been fact-checked and a near-identical match (cosine distance < 0.05) with high confidence (≥ 0.70) exists in memory, the pipeline now skips Tavily search, synthesis, and VLM — returning the cached verdict directly. Implemented via a new return_cached_verdict node and cache_hit_check conditional router in the LangGraph.

Accurate verified_at Timestamps
query_memory now batch-fetches verdict timestamps from Neo4j after reranking, using an authoritative graph traversal ((Claim)-[:VERIFIED_AS]->(Verdict) with superseded filter). Neo4j value takes priority over potentially stale ChromaDB metadata.

Claim Isolation Quality Improvements

Claim count capped at 1–3 (was 1–5) per article
Claims must be fully self-contained (no unresolved pronouns)
Hedged/vague claims excluded
Article body truncated to first 3000 chars (both URL and text paths) — ClaimIsolator sees lead paragraphs where primary verifiable claims are concentrated; full body still used for content hash deduplication
Tavily Evidence Quality Filters

Relevance score threshold lowered from 0.90 to 0.85
Tavily results matching the user's input URL are dropped (prevents circular self-corroboration)
Per-question cap of top 2 results by score applied before _summarise_search LLM calls — eliminates wasted summarization calls
Context Claim Optimisation

Memory claims capped at top 5 by prior confidence
Named constants _MAX_MEMORY_CLAIMS = 5 and _MAX_CLAIMS_PER_QUESTION = 2 replace magic numbers
Verdict Synthesis — Memory Claim Handling
Added explicit instruction to VERDICT_SYNTHESIS_PROMPT: prior verdict label maps directly to Di (positive for "supported", negative for "refuted", scaled by match closeness). Prevents the LLM from silently treating a prior refuted verdict as neutral evidence.

Cross-Encoder Removed
cross_encoder_rerank and _load_cross_encoder removed from reranker.py. rerank_candidates simplified to RRF-only. use_cross_encoder and cross_encoder_model config fields removed. Tests updated accordingly.